### PR TITLE
Remove unused imports that are not supported pre node v12.12.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "import-conductor",
-  "version": "1.1.0",
+  "version": "1.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,6 @@ import chalk from 'chalk';
 import commander from 'commander';
 import * as fs from 'fs';
 import * as gitChangedFiles from 'git-changed-files';
-import { resolve, join } from 'path';
 import ts from 'typescript';
 import { promisify } from 'util';
 
@@ -15,7 +14,6 @@ import { getFilePathsFromRegex } from './regex-helper';
 
 const git: SimpleGit = simpleGit();
 const readFile = promisify(fs.readFile);
-const opendir = promisify(fs.opendir);
 const writeFile = promisify(fs.writeFile);
 
 const collect = (value, previous) => previous.concat([value]);


### PR DESCRIPTION
The `fs.opendir` API was only added in node v12.12.0 https://nodejs.org/api/fs.html#fs_fs_opendir_path_options_callback

Since this import was not even being used I have removed it so I can use this tool in my projects that are still on older node versions.

[fixes #12](https://github.com/kreuzerk/import-conductor/issues/12)