### PR TITLE
fix: 🐛 Fixed case with empty separator added

### DIFF
--- a/__tests__/optimize-imports-mocks.ts
+++ b/__tests__/optimize-imports-mocks.ts
@@ -1,4 +1,4 @@
-export type TestCase = { input: string; expected: string };
+export type TestCase = { input: string; expected: string; noOfRuns?: number };
 
 export const readmeExample: TestCase = {
   input: `import fs from 'fs';
@@ -96,4 +96,18 @@ declare var global: any**
 if (environment.production) {
   enableProdMode();
 }`,
+};
+
+export const emptyNewLineSeparator: TestCase = {
+  noOfRuns: 2,
+  input: `import { Component, HostListener } from '@angular/core';
+  import { Observable } from 'rxjs';
+  import { MatDialogRef } from '@angular/material/dialog';
+
+  
+  import { AboutDialogBloc, AboutState } from './about-dialog.bloc';`,
+  expected: `import { Component, HostListener } from '@angular/core';
+import { Observable } from 'rxjs';
+import { MatDialogRef } from '@angular/material/dialog';
+import { AboutDialogBloc, AboutState } from './about-dialog.bloc';`,
 };

--- a/src/conductor/format-import-statements.ts
+++ b/src/conductor/format-import-statements.ts
@@ -27,5 +27,15 @@ function hasImports([, imports]: CategoryEntry) {
 }
 
 function toImportBlock([, imports]: CategoryEntry) {
-  return [...imports.values()].join('\n');
+  return [...imports.values()].map((l) => trim(l, ' \n')).join('\n');
+}
+
+function escapeRegex(string: string) {
+  return string.replace(/[\[\](){}?*+\^$\\.|\-]/g, '\\$&');
+}
+
+function trim(input: string, characters: string) {
+  characters = escapeRegex(characters);
+
+  return input.replace(new RegExp('^[' + characters + ']+|[' + characters + ']+$', 'g'), '');
 }


### PR DESCRIPTION
Fixed https://github.com/kreuzerk/import-conductor/issues/48