### PR TITLE
fix: verifyng action before update file

### DIFF
--- a/src/conductor/organize-imports.ts
+++ b/src/conductor/organize-imports.ts
@@ -45,8 +45,9 @@ export async function organizeImportsForFile(filePath: string): Promise<string> 
   const { staged, autoAdd, dryRun } = getConfig();
   const fileWithOrganizedImports = await organizeImports(fileContent);
   const fileHasChanged = fileWithOrganizedImports !== fileContent;
+  const isValidAction = [actions.none, actions.skipped].every(action => action !== fileWithOrganizedImports);
 
-  if (fileHasChanged) {
+  if (fileHasChanged && isValidAction) {
     !dryRun && writeFileSync(filePath, fileWithOrganizedImports);
     let msg = 'imports reordered';
     if (staged && autoAdd) {


### PR DESCRIPTION
Fix [issue](https://github.com/kreuzerk/import-conductor/issues/78);

Validating return from organizeImports function before update file. The organizeImports functions can return a action as string or updated file string.